### PR TITLE
Disable controls for `children` prop on card stories

### DIFF
--- a/stories/Card/FilledCard.stories.js
+++ b/stories/Card/FilledCard.stories.js
@@ -25,6 +25,9 @@ export default {
     skin: {
       control: { type: "radio", options: filledCardChoices.skin },
     },
+    children: {
+      control: false,
+    },
   },
 };
 
@@ -45,5 +48,5 @@ export const FilledCard = (args) => (
 
 FilledCard.args = {
   color: "mineral",
-  skin: "pale"
-}
+  skin: "pale",
+};

--- a/stories/Card/OutlineCard.stories.js
+++ b/stories/Card/OutlineCard.stories.js
@@ -25,6 +25,9 @@ export default {
     skin: {
       control: { type: "radio", options: outlineCardChoices.skin },
     },
+    children: {
+      control: false,
+    },
   },
 };
 

--- a/stories/Card/OutlineFilledCard.stories.js
+++ b/stories/Card/OutlineFilledCard.stories.js
@@ -22,6 +22,9 @@ export default {
     color: {
       control: { type: "radio", options: outlineFilledCardChoices.color },
     },
+    children: {
+      control: false,
+    },
   },
 };
 

--- a/stories/Card/WithDoubleAction.stories.js
+++ b/stories/Card/WithDoubleAction.stories.js
@@ -25,6 +25,9 @@ export default {
     skin: {
       control: { type: "radio", options: outlineCardChoices.skin },
     },
+    children: {
+      control: false,
+    },
   },
 };
 

--- a/stories/Card/WithLinkAction.stories.js
+++ b/stories/Card/WithLinkAction.stories.js
@@ -25,6 +25,9 @@ export default {
     skin: {
       control: { type: "radio", options: outlineCardChoices.skin },
     },
+    children: {
+      control: false,
+    },
   },
 };
 

--- a/stories/Card/WithOverflowedImage.stories.js
+++ b/stories/Card/WithOverflowedImage.stories.js
@@ -25,6 +25,9 @@ export default {
     skin: {
       control: { type: "radio", options: outlineCardChoices.skin },
     },
+    children: {
+      control: false,
+    },
   },
 };
 

--- a/stories/Card/WithOverlaidHeader.stories.js
+++ b/stories/Card/WithOverlaidHeader.stories.js
@@ -25,6 +25,9 @@ export default {
     skin: {
       control: { type: "radio", options: outlineCardChoices.skin },
     },
+    children: {
+      control: false,
+    },
   },
 };
 


### PR DESCRIPTION
**Link to task:** https://labcodes.atlassian.net/browse/CSYS-105

**Staging app:** https://migrate-card-qa--confetti-storybook.netlify.app/

**How to test:**
Go to all card stories and check that the `children` controls are removed.

**Description of your solution:**
Added the following code to all related stories argTypes:

```js
    children: {
      control: false,
    },
```

**Screenshots (when applicable):**
![image](https://user-images.githubusercontent.com/1103672/106954929-3ff51d00-6713-11eb-9b19-e69b15588cd1.png)
