### PR TITLE
CSYS-216: Disable control for `children` prop on Tooltip story 

### DIFF
--- a/stories/Tooltip.stories.js
+++ b/stories/Tooltip.stories.js
@@ -5,6 +5,11 @@ import { Tooltip as Component, Button } from "../confetti-ds/src";
 export default {
   title: "Tooltip/Tooltip",
   component: Component,
+  argTypes: {
+    children: {
+      control: false,
+    },
+  },
 };
 
 export const Tooltip = (args) => (


### PR DESCRIPTION
This PR is the couterpart to the similarly named PR on confetti-ds. Please check the other project to see if things make sense together.

**Link to task:** https://labcodes.atlassian.net/browse/CSYS-216

**Staging app:** https://migrate-tooltip-qa--confetti-storybook.netlify.app/

This PR is the couterpart to the similatly named PR on confetti-storybook. Please check the other project to see if things make sense together.

**How to test:**
- open the staging app
- check that the Tooltip story controls have the `children` control as disabled.

**Description of your solution:**
Added the following code to the Tooltip story argTypes:

```js
    children: {
      control: false,
    },
```

**Screenshots (when applicable):**
![image](https://user-images.githubusercontent.com/1103672/106956766-d75b6f80-6715-11eb-858f-88c2f640ce89.png)
