### PR TITLE
CSYS:200 Migrate narrow sidebar QA

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,5 @@
 import "!style-loader!css-loader!sass-loader!../confetti-ds/scss/main.scss";
+import "!style-loader!css-loader!sass-loader!./storybook-overrides.scss";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },

--- a/.storybook/storybook-overrides.scss
+++ b/.storybook/storybook-overrides.scss
@@ -1,0 +1,6 @@
+
+@media (min-width: 768px) {
+  .lab-narrow-sidebar {
+    position: static;
+  }
+}

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,7 @@
 Before submitting this pull request, make sure these boxes are checked. Thanks!
 
 - [ ] Review your code and QA it as the user. Double check if it does everything that was asked on the task.
+- [ ] Check your features both in Firefox **and** in a Chromium-based browser (Chrome, Brave, Chromium, Edge).
 - [ ] Merge the target branch into your branch and fix conflicts.
 - [ ] Look for forgotten comments, prints, console.log and typos.
 - [ ] YAGNI (You ain’t gonna need it) - Don’t do things that you don’t need yet.

--- a/stories/Sidebar/NarrowSidebar.stories.js
+++ b/stories/Sidebar/NarrowSidebar.stories.js
@@ -11,9 +11,6 @@ import { UserAvatar as UserAvatarStory } from "./subcomponents/UserAvatar.storie
 export default {
   title: "Sidebar/Narrow Sidebar",
   component: Component,
-  parameters: {
-    backgrounds: { default: "dark" },
-  },
   argTypes: {
     children: {
       control: false,

--- a/stories/Sidebar/NarrowSidebarWithFooterAvatar.stories.js
+++ b/stories/Sidebar/NarrowSidebarWithFooterAvatar.stories.js
@@ -12,9 +12,6 @@ import { UserAvatar as UserAvatarStory } from "./subcomponents/UserAvatar.storie
 export default {
   title: "Sidebar/Narrow Sidebar With Footer Avatar",
   component: Component,
-  parameters: {
-    backgrounds: { default: "dark" },
-  },
   argTypes: {
     children: {
       control: false,


### PR DESCRIPTION
**Link to task:** https://labcodes.atlassian.net/browse/CSYS-200

**Staging app:** https://migrate-narrow-sidebar-qa--confetti-storybook.netlify.app/

**How to test:**
- open the staging app
- check that the sidebar is visually inside of the stories, both in Firefox and Chrome

**Description of your solution:**
Added storybook CSS overrides to make the sidebar static, for visualization purposes.

**Screenshots:**
![image](https://user-images.githubusercontent.com/1103672/108562646-f0038200-72de-11eb-9d7d-786c66098bbf.png)

